### PR TITLE
Replace C-asserts with jasserts

### DIFF
--- a/modules/tracktion_graph/tracktion_graph/tracktion_graph_PlayHead.h
+++ b/modules/tracktion_graph/tracktion_graph/tracktion_graph_PlayHead.h
@@ -186,8 +186,8 @@ inline PlayHead::PlayHead() noexcept
 {
     // There isn't currently a lock-free implementation of this on Linux
    #if ! JUCE_LINUX && ! JUCE_WINDOWS
-    assert (referenceSampleRange.is_lock_free());
-    assert (syncPositions.is_lock_free());
+    jassert (referenceSampleRange.is_lock_free());
+    jassert (syncPositions.is_lock_free());
    #endif
 }
 


### PR DESCRIPTION
When debugging on Android, a C-assert ends up in a SIGABRT with no callstack (at least in this case and in my environment).